### PR TITLE
Fix bf.bat execution

### DIFF
--- a/tools/bf.bat
+++ b/tools/bf.bat
@@ -15,12 +15,6 @@ if "%BF_PROG%" == "" (
   goto end
 )
 
-rem Set the JVM flag.
-if "%BF_FLAGS%" == "" (
-  rem Set to default Garbage Collection.
-  set BF_FLAGS=""
-)
-
 rem Set the max heap size.
 if "%BF_MAX_MEM%" == "" (
   rem Set a reasonable default max heap size.


### PR DESCRIPTION
BF_FLAGS doesn't need to be explicitly set, and doing so will actually
cause "Error: Could not find or load main class" to be shown.
